### PR TITLE
Fitting reactivities with robust regression

### DIFF
--- a/do_new_likelihood_fit.m
+++ b/do_new_likelihood_fit.m
@@ -72,7 +72,7 @@ if exist( 'C_in' ) & ~isempty( C_in ) & JUST_SCALE_CIN
 else
     C = zeros(num_states, numres);
     for m = 1:numres
-        C(:,m) = robustfit(f'/sigma_at_each_residue(m), data_renorm(m, :)/sigma_at_each_residue(m), 'fair', 1.345, 'off');
+        C(:,m) = robustfit(f', data_renorm(m, :), 'fair', 1.345, 'off');
     end
   
   

--- a/do_new_likelihood_fit.m
+++ b/do_new_likelihood_fit.m
@@ -70,22 +70,10 @@ if exist( 'C_in' ) & ~isempty( C_in ) & JUST_SCALE_CIN
   C = diag(kappa) * C_in;
 
 else
-   C = zeros(num_states, numres);
-   A = f * f';
-   % reactivity of each state.
-   B =  data_renorm*f';
- 
-   if exist( 'C_in' ) & ~isempty( C_in )
-     A = A + beta;
-     B = B + beta * C_in';
-   end
-   
-   %C = A\B';
-   % to enforce that C is positive...
-   for m = 1:size( B, 1 );
-     C(:,m) = lsqnonneg( A/sigma_at_each_residue(m), (B(m,:)')/sigma_at_each_residue(m) );
-   end
-    
+    C = zeros(num_states, numres);
+    for m = 1:numres
+        C(:,m) = robustfit(f'/sigma_at_each_residue(m), data_renorm(m, :)/sigma_at_each_residue(m), 'fair', 1.345, 'off');
+    end
   
   
 end

--- a/lifft.m
+++ b/lifft.m
@@ -161,16 +161,22 @@ normfactor = mean(mean( input_data ) )/40;
 data_lane_norm = input_data*diag(lane_normalization);
 image( data_lane_norm/normfactor ); title( 'input data' )
 set(gca,'linew',2,'fontsize',14,'fontw','bold','yticklabel',resnum,'ytick',[1:size(input_data,1)]);
+set(gca,'linew',2,'fontsize',11,'fontw','bold','xticklabel',conc,'xtick',[1:size(input_data,2)]);
+xticklabel_rotate
 
 
 subplot(1,3,2);
 image( pred_fit/normfactor ); title( 'fits' )
 set(gca,'linew',2,'fontsize',14,'fontw','bold','yticklabel',resnum,'ytick',[1:size(input_data,1)]);
+set(gca,'linew',2,'fontsize',11,'fontw','bold','xticklabel',conc,'xtick',[1:size(input_data,2)]);
+xticklabel_rotate
 
 subplot(1,3,3);
 image( abs( pred_fit - data_lane_norm)/normfactor ); title( 'abs(residuals)' )
 colormap( 1 - gray(100) );
 set(gca,'linew',2,'fontsize',14,'fontw','bold','yticklabel',resnum,'ytick',[1:size(input_data,1)]);
+set(gca,'linew',2,'fontsize',11,'fontw','bold','xticklabel',conc,'xtick',[1:size(input_data,2)]);
+xticklabel_rotate
 set(gcf, 'PaperPositionMode','auto','color','white');
 
 


### PR DESCRIPTION
- Using robustfit instead of ordinary least squares prevents outliers that are sometimes found as 'bad' lanes in titrations
- Tried several forms of robust regressions. In tebowned datasets, 'fair' seems to give the best strategy.
- Also, added concentrations as xticklabels in grayscale plots
